### PR TITLE
add @computed decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ class TestElement extends Polymer.Element {
   private onBazChanged(newValue: string, oldValue: string) {
   }
 
+  // @computed replaces the getter with a computed property
+  @computed('foo')
+  get computedExample() {
+    return this.foo * 2;
+  }
+
+  // @computed also takes multiple parameters
+  @computed('foo', 'bar')
+  get computedExampleTwo() {
+    return `${this.bar}: ${this.foo}`;
+  }
+
   // @query replaces the property with a getter that querySelectors() in
   // the shadow root. Use this for type-safe access to internal nodes.
   @query('h1')

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -106,24 +106,26 @@ export function observe(targets: string|string[]) {
 }
 
 /**
- * A TypeScript accessor decorator factory that causes the decorated accessor to
- * be called when a property changes. `targets` is either a single property
- * name, or a list of property names.
+ * A TypeScript accessor decorator factory that causes the decorated getter to
+ * be called when a set of dependencies change. The arguments of this decorator
+ * should be paths of the data dependencies as described
+ * [here](https://www.polymer-project.org/2.0/docs/devguide/observers#define-a-computed-property)
+ * The decorated getter should not have an associated setter.
  *
  * This function must be invoked to return a decorator.
  */
 export function computed<T = any>(...targets: (keyof T)[]) {
   return (proto: any, propName: string, descriptor: PropertyDescriptor): void => {
-    const targetString = targets.join(',');
-    const propNameCased = propName[0].toUpperCase() + propName.slice(1);
-    const fnName = `__compute${propNameCased}`;
+    const fnName = `__compute${propName}`;
 
-    proto.constructor.prototype[fnName] = descriptor.get;
+    Object.defineProperty(proto, fnName, {
+      value: descriptor.get
+    });
 
     descriptor.get = undefined;
 
     createProperty(proto, propName, {
-      computed: `${fnName}(${targetString})`
+      computed: `${fnName}(${targets.join(',')})`
     });
   };
 }

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -106,6 +106,32 @@ suite('TypeScript Decorators', function() {
 
   });
 
+  suite('@computed', function() {
+
+    test('defines a computed property', function() {
+      testElement.dependencyOne = 'foo';
+
+      const compDiv = testElement.shadowRoot.querySelector('#computed');
+      chai.assert.equal(compDiv.textContent, 'foo');
+      chai.assert.equal(testElement.computedOne, 'foo');
+    });
+
+    test('defines a computed property with multiple arguments', function() {
+      testElement.dependencyOne = 'foo';
+
+      const compDiv = testElement.shadowRoot.querySelector('#computedTwo');
+
+      chai.assert.equal(compDiv.textContent, 'foo');
+      chai.assert.equal(testElement.computedTwo, 'foo');
+
+      testElement.dependencyTwo = 'bar';
+
+      chai.assert.equal(compDiv.textContent, 'foobar');
+      chai.assert.equal(testElement.computedTwo, 'foobar');
+    });
+
+  });
+
   suite('@query', function() {
 
     test('queries the shadow root', function() {
@@ -119,7 +145,7 @@ suite('TypeScript Decorators', function() {
 
     test('queries the shadow root', function() {
       const divs = testElement.divs;
-      chai.assert.equal(divs.length, 2);
+      chai.assert.equal(divs.length, 4);
     });
 
   });

--- a/test/integration/elements/test-element.html
+++ b/test/integration/elements/test-element.html
@@ -5,6 +5,8 @@
   <template>
     <div id="num">{{aNum}}</div>
     <div id="string">{{aString}}</div>
+    <div id="computed">{{computedOne}}</div>
+    <div id="computedTwo">{{computedTwo}}</div>
   </template>
   <script src="./test-element.js"></script>
 </dom-module>

--- a/test/integration/elements/test-element.ts
+++ b/test/integration/elements/test-element.ts
@@ -11,7 +11,7 @@
 
 /// <reference path="../bower_components/polymer-decorators/global.d.ts" />
 
-const {customElement, property, query, queryAll, observe} = Polymer.decorators;
+const {customElement, property, query, queryAll, observe, computed} = Polymer.decorators;
 
 @customElement('test-element')
 class TestElement extends Polymer.Element {
@@ -39,6 +39,18 @@ class TestElement extends Polymer.Element {
   @property({observer:'observeString'})
   observedString: string;
   
+  @property()
+  dependencyOne: string = '';
+
+  @property()
+  dependencyTwo: string = '';
+
+  @computed('dependencyOne')
+  get computedOne() { return this.dependencyOne; }
+
+  @computed('dependencyOne', 'dependencyTwo')
+  get computedTwo() { return this.dependencyOne + this.dependencyTwo; }
+
   // stand-in for set function dynamically created by Polymer on read only properties
   _setReadOnlyString: (value: string) => void;
 


### PR DESCRIPTION
This is a computed decorator (fixes #17).

The way its expected to be used is as follows:

```
@computed(['a', 'b'])
public get myComputedProperty() {
  return `a: ${this.a}, b: ${this.b}`;
}
```

---

**It only supports simple parameters!**

What this means is that splices, wildcards, length, etc. will not work. Anything which would require us to pass something into the computation function is not supported here. For that, **you should create a `@property` with `computed` set manually**.

To me this seems like a sacrifice worth giving so simple computations can remain as what they really are: getters. If you think otherwise, speak up and we can discuss how to support complex ones too.