### PR TITLE
add a simple observer readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ class TestElement extends Polymer.Element {
   @property()
   bar: string = 'yes';
 
+  // @observe does not support simple observers,
+  // you can already do that via a normal property
+  @property({ observer: TestElement.prototype.onBazChanged })
+  baz: string = 'test';
+
+  private onBazChanged(newValue: string, oldValue: string) {
+  }
+
   // @query replaces the property with a getter that querySelectors() in
   // the shadow root. Use this for type-safe access to internal nodes.
   @query('h1')

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -42,6 +42,7 @@ export interface PropertyOptions {
   notify?: boolean;
   reflectToAttribute?: boolean;
   readOnly?: boolean;
+  observer?: string|((val: any, old: any) => void);
 }
 
 /**


### PR DESCRIPTION
Updated the readme a tiny bit to explain how to do a simple observer (a property's observer).

would typescript complain about this? doesn't seem to locally but wasn't sure about accessing a private method on the prototype.