### PR TITLE
The @observe decorator now takes a rest parameter instead of an array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Generated typings for the `DeclarativeEventListeners` mixin are now available at `mixins/declarative-event-listeners.d.ts`.
+- [BREAKING] The `@observe` decorator now takes its dependencies as a rest parameter instead of an array (e.g. `@observer('foo', 'bar')` instead of `@observer(['foo', 'bar'])`.
 
 ## [0.1.2] - 2018-01-01
 - Added `observer` and `computed` properties to the `@property` decorator options.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ class MyElement extends Polymer.Element {
    - [@customElement](#customelementtagname-string)
    - [@property](#propertyoptions-propertyobjects)
    - [@computed](#computedtargets-string)
-   - [@observe](#observetargets-stringstring)
+   - [@observe](#observetargets-string)
    - [@query](#queryselector-string)
    - [@queryAll](#queryallselector-string)
    - [@listen](#listeneventname-string-target-stringeventtarget)
@@ -166,7 +166,7 @@ private computeBaz(fooChangeRecord: object) {
 }
 ```
 
-### `@observe(targets: string|string[])`
+### `@observe(...targets: string[])`
 
 Define a [complex property
 observer](https://www.polymer-project.org/2.0/docs/devguide/observers#complex-observers).
@@ -176,12 +176,7 @@ observer dependency syntaxes are supported (property names, sub-properties,
 splices, wildcards, etc.).
 
 ```ts
-@observe('foo')
-private fooChanged(newFoo: string) {
-  console.log(`foo is now: ${newFoo}`);
-}
-
-@observe(['foo', 'bar'])
+@observe('foo', 'bar')
 private fooBarChanged(newFoo: string, newBar: string) {
   console.log(`foo is now: ${newFoo}, bar is now: ${newBar}`);
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -90,19 +90,16 @@ export function property(options?: PropertyOptions) {
 
 /**
  * A TypeScript property decorator factory that causes the decorated method to
- * be called when a property changes. `targets` is either a single property
- * name, or a list of property names.
+ * be called when a property changes.
  *
  * This function must be invoked to return a decorator.
  */
-export function observe(targets: string|string[]) {
+export function observe(...targets: string[]) {
   return (proto: any, propName: string): any => {
-    const targetString =
-        typeof targets === 'string' ? targets : targets.join(',');
     if (!proto.constructor.hasOwnProperty('observers')) {
       proto.constructor.observers = [];
     }
-    proto.constructor.observers.push(`${propName}(${targetString})`);
+    proto.constructor.observers.push(`${propName}(${targets.join(',')})`);
   }
 }
 

--- a/test/integration/elements/test-element.ts
+++ b/test/integration/elements/test-element.ts
@@ -76,7 +76,7 @@ class TestElement extends Polymer.Element {
     this._setReadOnlyString('initial value')
   }
 
-  @observe(['aNum', 'aString'])
+  @observe('aNum', 'aString')
   private _numStringChanged(newNum: number, newString: string) {
     this.lastMultiChange = [newNum, newString];
   }


### PR DESCRIPTION
This is more ergonomic, and makes it consistent with `@compute`. Breaking change! This will be released with 1.0.