### PR TITLE
Fix Safari test, rename global.js to polymer-decorators.js, prepare 1.0.0 release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bower_components/
 lib/
 node_modules/
-global.js
-global.d.ts
+polymer-decorators.js
+polymer-decorators.d.ts
 polymer-decorators*.tgz
 mixins/*.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Generated typings for the `DeclarativeEventListeners` mixin are now available at `mixins/declarative-event-listeners.d.ts`.
 - [BREAKING] The `@observe` decorator now takes its dependencies as a rest parameter instead of an array (e.g. `@observer('foo', 'bar')` instead of `@observer(['foo', 'bar'])`.
+- [BREAKING] Decorators are now located at `polymer-decorators.js` instead of `global.js` (same for corresponding `.d.ts` file).
 
 ## [0.1.2] - 2018-01-01
 - Added `observer` and `computed` properties to the `@property` decorator options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+
+## [1.0.0] - 2018-01-10
 - Generated typings for the `DeclarativeEventListeners` mixin are now available at `mixins/declarative-event-listeners.d.ts`.
 - [BREAKING] The `@observe` decorator now takes its dependencies as a rest parameter instead of an array (e.g. `@observer('foo', 'bar')` instead of `@observer(['foo', 'bar'])`.
 - [BREAKING] Decorators are now located at `polymer-decorators.js` instead of `global.js` (same for corresponding `.d.ts` file).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class MyElement extends Polymer.Element {
 
    ```ts
    /// <reference path="./bower_components/polymer/types/polymer-element.d.ts" />
-   /// <reference path="./bower_components/polymer-decorators/global.d.ts" />
+   /// <reference path="./bower_components/polymer-decorators/polymer-decorators.d.ts" />
    ```
 
 4. Enable the

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "polymer-decorators",
   "homepage": "https://github.com/Polymer/polymer-decorators",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "authors": [
     "The Polymer Project Authors"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/decorators",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/decorators",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "TypeScript decorators for Polymer 2.0",
   "main": "lib/decorators.js",
   "types": "lib/decorators.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/decorators.js",
   "types": "lib/decorators.d.ts",
   "scripts": {
-    "clean": "rm -rf lib global.{js,d.ts} mixins/*.d.ts test/integration/{node_modules,bower_components,bower_cache}",
+    "clean": "rm -rf lib polymer-decorators.{js,d.ts} mixins/*.d.ts test/integration/{node_modules,bower_components,bower_cache}",
     "format": "find src -name '*.ts' | xargs clang-format --style=file -i",
     "build": "npm run clean && tsc && rollup -c && node scripts/gen-global-typings.js && gen-typescript-declarations --outDir=.",
     "prepack": "npm run build",

--- a/polymer-decorators.html
+++ b/polymer-decorators.html
@@ -1,1 +1,1 @@
-<script src="./global.js"></script>
+<script src="./polymer-decorators.js"></script>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 export default {
   input: 'lib/decorators.js',
   output: {
-    file: 'global.js',
+    file: 'polymer-decorators.js',
     format: 'iife',
     name: 'Polymer.decorators',
   }

--- a/scripts/gen-global-typings.js
+++ b/scripts/gen-global-typings.js
@@ -1,6 +1,6 @@
-// This script generates global.d.ts, a transformation of the type declarations
-// of the decorators module into the Polymer.decorators global namespace, which
-// corresponds to what our rollup configuration does.
+// This script generates polymer-decorators.d.ts, a transformation of the type
+// declarations of the decorators module into the Polymer.decorators global
+// namespace, which corresponds to what our rollup configuration does.
 //
 // This script should typically be run with `npm run build`.
 
@@ -22,4 +22,4 @@ ${
   }
 }
 `
-fs.writeFileSync('global.d.ts', output);
+fs.writeFileSync('polymer-decorators.d.ts', output);

--- a/test/integration/bower.json
+++ b/test/integration/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "polymer-decorators-integration-test",
   "dependencies": {
-    "polymer": "^2.4.0-rc.1",
+    "polymer": "#d7ea2464cd7e798c1bc4ebf25e12d17c43a6f8b4",
     "webcomponentsjs": "^1.0.12",
     "polymer-decorators": "../../",
     "reflect-metadata": "rbuckton/reflect-metadata#^0.1.10"

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -19,10 +19,10 @@ suite('TypeScript Decorators', function() {
   setup(function() {
     testElement = fixture('test-element-fixture') as TestElement;
     gestureListenerTestElement =
-        fixture('gesture-listener-test-element-fixture') as
+        fixture('gesture-listener-test-element-fixture') as any as
         GestureListenerTestElement;
     declarativeListenerTestElement =
-        fixture('declarative-listener-test-element-fixture') as
+        fixture('declarative-listener-test-element-fixture') as any as
         DeclarativeListenerTestElement;
   });
 
@@ -37,7 +37,8 @@ suite('TypeScript Decorators', function() {
     });
 
     test('defines an element with a mixin behavior', function() {
-      const el = fixture('mixin-behaviors-test-element-fixture') as MixinBehaviorsTestElement;
+      const el = fixture('mixin-behaviors-test-element-fixture') as any as
+          MixinBehaviorsTestElement;
       chai.assert.instanceOf(el, MixinBehaviorsTestElement);
       chai.assert.equal(el.elementProperty, 'elementPropertyValue');
       chai.assert.equal((el as any).behaviorProperty, 'behaviorPropertyValue');
@@ -89,15 +90,15 @@ suite('TypeScript Decorators', function() {
       const propValue = testElement.readOnlyString;
       chai.assert.equal(propValue, 'initial value');
     });
-    
+
     test('computed property should return computed value', function() {
-      testElement.computedString = "new value";
+      testElement.computedString = 'new value';
       const propValue = testElement.computedString;
       chai.assert.equal(propValue, 'computed yahoo');
     });
-    
+
     test('observer property function should be invoked', function() {
-      testElement.observedString = "new value";
+      testElement.observedString = 'new value';
       const propValue = testElement.lastChange;
       chai.assert.equal(propValue, 'new value');
     });
@@ -118,7 +119,6 @@ suite('TypeScript Decorators', function() {
   });
 
   suite('@computed', function() {
-
     test('defines a computed property', function() {
       testElement.dependencyOne = 'foo';
 
@@ -140,7 +140,6 @@ suite('TypeScript Decorators', function() {
       chai.assert.equal(compDiv.textContent, 'foobar');
       chai.assert.equal(testElement.computedTwo, 'foobar');
     });
-
   });
 
   suite('@query', function() {

--- a/test/integration/tsconfig.json
+++ b/test/integration/tsconfig.json
@@ -12,7 +12,7 @@
     "*.ts",
     "elements/**/*.ts",
     "bower_components/polymer/types/polymer.d.ts",
-    "bower_components/polymer-decorators/global.d.ts",
+    "bower_components/polymer-decorators/polymer-decorators.d.ts",
     "bower_components/polymer-decorators/mixins/declarative-event-listeners.d.ts"
   ]
 }


### PR DESCRIPTION
- Fix Safari test failure by pinning to latest Polymer. Polymer/polymer#5029 was the underlying fix. Fixes #27.
- Rename `global.js` to `polymer-decorators.js`. I called it `global.js` originally because I thought we might ship a modules version and global version in the same package. I don't think we'll do that though; we'll have two versions instead. Since you often see just the filename (e.g. in Chrome devtools), it's nicer for it to be more descriptive.
- Prepare 1.0.0 release.