### PR TITLE
allow redefintion of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-<!-- ## [Unreleased] -->
+## [Unreleased] 
+- Allow multiple decorators to be combined
 
 ## [1.0.2] - 2018-01-26
 - Fix missing generated files from `1.0.1` release.

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ configuration. This is especially useful to apply a `type` without needing
 the metadata API.
 
 ```ts
-@property({type: String})
 @computed<MyElement>('foo', 'bar')
+@property({type: String})
 get fooBar() {
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ private computeBaz(fooChangeRecord: object) {
 }
 ```
 
+Also note that you may combine `@property` and `@computed` for additional
+configuration. This is especially useful to apply a `type` without needing
+the metadata API.
+
+```ts
+@property({type: String})
+@computed<MyElement>('foo', 'bar')
+get fooBar() {
+```
+
 ### `@observe(...targets: string[])`
 
 Define a [complex property

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/decorators",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,13 +52,13 @@ function createProperty(
     Object.defineProperty(proto.constructor, 'properties', {value: {}});
   }
 
-  const finalOpts: PropertyOptions =
-      {...proto.constructor.properties[name], ...options};
+  const finalOpts: PropertyOptions = {
+    ...proto.constructor.properties[name] as PropertyOptions | undefined,
+    ...options
+  };
 
   if (!finalOpts.type) {
-    if ((window as any).Reflect &&
-        Reflect.hasMetadata &&
-        Reflect.getMetadata &&
+    if ((window as any).Reflect && Reflect.hasMetadata && Reflect.getMetadata &&
         Reflect.hasMetadata('design:type', proto, name)) {
       finalOpts.type = Reflect.getMetadata('design:type', proto, name);
     } else {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,12 +52,8 @@ function createProperty(
     Object.defineProperty(proto.constructor, 'properties', {value: {}});
   }
 
-  let finalOpts: PropertyOptions =
-      proto.constructor.properties[name] || {};
-
-  if (options) {
-    finalOpts = {...finalOpts, ...options};
-  }
+  const finalOpts: PropertyOptions =
+      {...proto.constructor.properties[name], ...options};
 
   if (!finalOpts.type) {
     if ((window as any).Reflect &&

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -64,16 +64,17 @@ function createProperty(
     finalOpts.type = options.type || finalOpts.type;
   }
 
-  if (!finalOpts.type &&
-      (window as any).Reflect &&
-      Reflect.hasMetadata &&
-      Reflect.getMetadata &&
-      Reflect.hasMetadata('design:type', proto, name)) {
-    finalOpts.type = Reflect.getMetadata('design:type', proto, name);
-  } else {
-    console.error(
-        `A type could not be found for ${name}. ` +
-        'Set a type or configure Metadata Reflection API support.');
+  if (!finalOpts.type) {
+    if ((window as any).Reflect &&
+        Reflect.hasMetadata &&
+        Reflect.getMetadata &&
+        Reflect.hasMetadata('design:type', proto, name)) {
+      finalOpts.type = Reflect.getMetadata('design:type', proto, name);
+    } else {
+      console.error(
+          `A type could not be found for ${name}. ` +
+          'Set a type or configure Metadata Reflection API support.');
+    }
   }
 
   proto.constructor.properties[name] = finalOpts;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,16 +52,33 @@ function createProperty(
     Object.defineProperty(proto.constructor, 'properties', {value: {}});
   }
 
-  const finalOpts: PropertyOptions = proto.constructor.properties[name] || {};
+  const defaultOpts: PropertyOptions = {
+    notify: false,
+    reflectToAttribute: false,
+    readOnly: false
+  };
+  const finalOpts: PropertyOptions =
+      proto.constructor.properties[name] || defaultOpts;
 
   if (options) {
-    finalOpts.notify = options.notify || finalOpts.notify || false;
-    finalOpts.reflectToAttribute =
-      options.reflectToAttribute || finalOpts.reflectToAttribute ||false;
-    finalOpts.readOnly = options.readOnly || finalOpts.readOnly || false;
-    finalOpts.computed = options.computed || finalOpts.computed || '';
-    finalOpts.observer = options.observer || finalOpts.observer || '';
-    finalOpts.type = options.type || finalOpts.type;
+    if (options.notify !== undefined) {
+      finalOpts.notify = options.notify;
+    }
+    if (options.reflectToAttribute !== undefined) {
+      finalOpts.reflectToAttribute = options.reflectToAttribute;
+    }
+    if (options.readOnly !== undefined) {
+      finalOpts.readOnly = options.readOnly;
+    }
+    if (options.computed !== undefined) {
+      finalOpts.computed = options.computed;
+    }
+    if (options.observer !== undefined) {
+      finalOpts.observer = options.observer;
+    }
+    if (options.type !== undefined) {
+      finalOpts.type = options.type;
+    }
   }
 
   if (!finalOpts.type) {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,33 +52,11 @@ function createProperty(
     Object.defineProperty(proto.constructor, 'properties', {value: {}});
   }
 
-  const defaultOpts: PropertyOptions = {
-    notify: false,
-    reflectToAttribute: false,
-    readOnly: false
-  };
-  const finalOpts: PropertyOptions =
-      proto.constructor.properties[name] || defaultOpts;
+  let finalOpts: PropertyOptions =
+      proto.constructor.properties[name] || {};
 
   if (options) {
-    if (options.notify !== undefined) {
-      finalOpts.notify = options.notify;
-    }
-    if (options.reflectToAttribute !== undefined) {
-      finalOpts.reflectToAttribute = options.reflectToAttribute;
-    }
-    if (options.readOnly !== undefined) {
-      finalOpts.readOnly = options.readOnly;
-    }
-    if (options.computed !== undefined) {
-      finalOpts.computed = options.computed;
-    }
-    if (options.observer !== undefined) {
-      finalOpts.observer = options.observer;
-    }
-    if (options.type !== undefined) {
-      finalOpts.type = options.type;
-    }
+    finalOpts = {...finalOpts, ...options};
   }
 
   if (!finalOpts.type) {

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -54,7 +54,7 @@ suite('TypeScript Decorators', function() {
     });
 
     test('merges multiple definitions', function() {
-      chai.assert.deepEqual((testElement as any).properties, {
+      chai.assert.deepEqual((testElement as any).properties.computedWithOptions, {
         notify: false,
         reflectToAttribute: false,
         readOnly: false,

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -55,9 +55,8 @@ suite('TypeScript Decorators', function() {
 
     test('merges multiple definitions', function() {
       chai.assert.deepEqual((TestElement as any).properties.computedWithOptions, {
-        notify: false,
-        reflectToAttribute: false,
-        readOnly: false,
+        computed: '__computecomputedWithOptions(dependencyOne)',
+        readOnly: true,
         type: String
       });
     });

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -58,8 +58,6 @@ suite('TypeScript Decorators', function() {
         notify: false,
         reflectToAttribute: false,
         readOnly: false,
-        computed: '',
-        observer: '',
         type: String
       });
     });

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -53,6 +53,17 @@ suite('TypeScript Decorators', function() {
       chai.assert.equal(numText, '999');
     });
 
+    test('merges multiple definitions', function() {
+      chai.assert.deepEqual((testElement as any).properties, {
+        notify: false,
+        reflectToAttribute: false,
+        readOnly: false,
+        computed: '',
+        observer: '',
+        type: String
+      });
+    });
+
     test('notify property should fire events', function() {
       let fired = false;
       const fn = function() {

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -54,7 +54,7 @@ suite('TypeScript Decorators', function() {
     });
 
     test('merges multiple definitions', function() {
-      chai.assert.deepEqual((testElement as any).properties.computedWithOptions, {
+      chai.assert.deepEqual((TestElement as any).properties.computedWithOptions, {
         notify: false,
         reflectToAttribute: false,
         readOnly: false,

--- a/test/integration/elements/test-element.ts
+++ b/test/integration/elements/test-element.ts
@@ -50,6 +50,10 @@ class TestElement extends Polymer.Element {
   @computed<TestElement>('dependencyOne', 'dependencyTwo')
   get computedTwo() { return this.dependencyOne + this.dependencyTwo; }
 
+  @computed('dependencyOne')
+  @property({type: String})
+  get computedWithOptions() { return this.dependencyOne; }
+
   // stand-in for set function dynamically created by Polymer on read only
   // properties
   _setReadOnlyString: (value: string) => void;

--- a/test/integration/elements/test-element.ts
+++ b/test/integration/elements/test-element.ts
@@ -50,8 +50,8 @@ class TestElement extends Polymer.Element {
   @computed<TestElement>('dependencyOne', 'dependencyTwo')
   get computedTwo() { return this.dependencyOne + this.dependencyTwo; }
 
-  @computed('dependencyOne')
   @property({type: String})
+  @computed('dependencyOne')
   get computedWithOptions() { return this.dependencyOne; }
 
   // stand-in for set function dynamically created by Polymer on read only


### PR DESCRIPTION
this should in theory allow people to use the `computed` decorator without the metadata API:

```js
@property({ type: String })
@computed('a', 'b')
get computeMe() {
```

also just means you can have multiple decorators if you must.

im having build issues locally, something to do with my TS version i guess so i dont think it is passing in ci yet