### PR TITLE
Remove npm dependency on reflect-metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 <!-- ## [Unreleased] -->
+- Remove npm dependency on `reflect-metadata` package.
 
 ## [1.1.0] - 2018-02-14
 - Allow `@property` to be used together with `@computed` so that its `type` can be set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/decorators",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,11 +841,6 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
-    },
-    "reflect-metadata": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
-      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
     },
     "regenerator-runtime": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "url": "https://github.com/Polymer/polymer-decorators/issues"
   },
   "homepage": "https://github.com/Polymer/polymer-decorators#readme",
-  "dependencies": {
-    "reflect-metadata": "^0.1.10"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.1.3",
     "clang-format": "^1.0.55",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,7 +9,23 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-/// <reference types="reflect-metadata" />
+// Maybe the Metadata Reflection API is available. Inline some types here
+// because we don't want this package to depend on the polyfill just to get the
+// typings (https://github.com/rbuckton/reflect-metadata), plus we want them
+// typed as possibly undefined.
+declare global {
+  interface Window {
+    Reflect?: {
+      hasMetadata?: (metadataKey: any,
+                     target: Object,
+                     targetKey: string|symbol) => boolean;
+
+      getMetadata?: (metadataKey: any,
+                     target: Object,
+                     targetKey: string|symbol) => any;
+    };
+  }
+}
 
 /**
  * A TypeScript class decorator factory that defines a custom element with name
@@ -58,9 +74,10 @@ function createProperty(
   };
 
   if (!finalOpts.type) {
-    if ((window as any).Reflect && Reflect.hasMetadata && Reflect.getMetadata &&
-        Reflect.hasMetadata('design:type', proto, name)) {
-      finalOpts.type = Reflect.getMetadata('design:type', proto, name);
+    if (window.Reflect && window.Reflect.hasMetadata &&
+        window.Reflect.getMetadata &&
+        window.Reflect.hasMetadata('design:type', proto, name)) {
+      finalOpts.type = window.Reflect.getMetadata('design:type', proto, name);
     } else {
       console.error(
           `A type could not be found for ${name}. ` +

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,24 +9,6 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-// Maybe the Metadata Reflection API is available. Inline some types here
-// because we don't want this package to depend on the polyfill just to get the
-// typings (https://github.com/rbuckton/reflect-metadata), plus we want them
-// typed as possibly undefined.
-declare global {
-  interface Window {
-    Reflect?: {
-      hasMetadata?: (metadataKey: any,
-                     target: Object,
-                     targetKey: string|symbol) => boolean;
-
-      getMetadata?: (metadataKey: any,
-                     target: Object,
-                     targetKey: string|symbol) => any;
-    };
-  }
-}
-
 /**
  * A TypeScript class decorator factory that defines a custom element with name
  * `tagname` and the decorated class. If `tagname` is not provided, the static
@@ -74,10 +56,10 @@ function createProperty(
   };
 
   if (!finalOpts.type) {
-    if (window.Reflect && window.Reflect.hasMetadata &&
-        window.Reflect.getMetadata &&
-        window.Reflect.hasMetadata('design:type', proto, name)) {
-      finalOpts.type = window.Reflect.getMetadata('design:type', proto, name);
+    const reflect = (window as any).Reflect;
+    if (reflect.hasMetadata && reflect.getMetadata &&
+        reflect.hasMetadata('design:type', proto, name)) {
+      finalOpts.type = reflect.getMetadata('design:type', proto, name);
     } else {
       console.error(
           `A type could not be found for ${name}. ` +


### PR DESCRIPTION
We don't want this package to depend on the polyfill just to get the typings (https://github.com/rbuckton/reflect-metadata).