### PR TITLE
Better handling of "tagname" param vs "is" class property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 <!-- ## [Unreleased] -->
+- An exception is now thrown if both the `tagname` parameter to `@customElement` is provided, and the static `is` class property is set (except in the case that the `is` property is not an own-property of the class). Previously the `is` property would always silently win over the `tagname` when both were set.
 
 ## [1.1.1] - 2018-02-16
 - Remove npm dependency on `reflect-metadata` package.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ const {customElement, property} = Polymer.decorators;
 
 Define a custom element.
 
-`tagname` is the name to register this element with. If omitted, the static
-`is` class property is used. Also sets the `is` property on the class if not
-already set.
+If `tagname` is provided, it will be used as the custom element name, and will
+be assigned to the class static `is` property. If `tagname` is omitted, the
+static `is` property of the class will be used instead. If neither exist, or if
+both exist but have different values (except in the case that the `is` property
+is not an own-property of the class), an exception is thrown.
 
 This decorator automatically calls
 [`customElements.define()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define)

--- a/polymer-decorators.d.ts
+++ b/polymer-decorators.d.ts
@@ -14,11 +14,18 @@ declare namespace Polymer {
      * rights grant found at http://polymer.github.io/PATENTS.txt
      */
     /**
-     * A TypeScript class decorator factory that defines a custom element with name
-     * `tagname` and the decorated class. If `tagname` is not provided, the static
-     * `is` property of the class is used.
+     * A TypeScript class decorator factory that registers the class as a custom
+     * element.
+     *
+     * If `tagname` is provided, it will be used as the custom element name, and
+     * will be assigned to the class static `is` property. If `tagname` is omitted,
+     * the static `is` property of the class will be used instead. If neither exist,
+     * or if both exist but have different values (except in the case that the `is`
+     * property is not an own-property of the class), an exception is thrown.
      */
-    function customElement(tagname?: string): (clazz: any) => void;
+    function customElement(tagname?: string): (class_: Function & {
+        is?: string | undefined;
+    }) => void;
     /**
      * Options for the @property decorator.
      * See https://www.polymer-project.org/2.0/docs/devguide/properties.

--- a/polymer-decorators.js
+++ b/polymer-decorators.js
@@ -15,21 +15,33 @@ this.Polymer.decorators = (function (exports) {
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 /**
- * A TypeScript class decorator factory that defines a custom element with name
- * `tagname` and the decorated class. If `tagname` is not provided, the static
- * `is` property of the class is used.
+ * A TypeScript class decorator factory that registers the class as a custom
+ * element.
+ *
+ * If `tagname` is provided, it will be used as the custom element name, and
+ * will be assigned to the class static `is` property. If `tagname` is omitted,
+ * the static `is` property of the class will be used instead. If neither exist,
+ * or if both exist but have different values (except in the case that the `is`
+ * property is not an own-property of the class), an exception is thrown.
  */
 function customElement(tagname) {
-    // TODO Investigate narrowing down the type of clazz.
-    return (clazz) => {
-        // TODO(justinfagnani): we could also use the kebab-cased class name
-        if (clazz.is) {
-            tagname = clazz.is;
+    return (class_) => {
+        if (tagname) {
+            // Only check that tag names match when `is` is our own property. It might
+            // be inherited from a superclass, in which case it's ok if they're
+            // different, and we'll override it with our own property below.
+            if (class_.hasOwnProperty('is')) {
+                if (tagname !== class_.is) {
+                    throw new Error(`custom element tag names do not match: ` +
+                        `(${tagname} !== ${class_.is})`);
+                }
+            }
+            else {
+                Object.defineProperty(class_, 'is', { value: tagname });
+            }
         }
-        else {
-            clazz.is = tagname;
-        }
-        window.customElements.define(tagname, clazz);
+        // Throws if tag name is missing or invalid.
+        window.customElements.define(class_.is, class_);
     };
 }
 function createProperty(proto, name, options) {

--- a/test/integration/decorators.ts
+++ b/test/integration/decorators.ts
@@ -43,6 +43,17 @@ suite('TypeScript Decorators', function() {
       chai.assert.equal(el.elementProperty, 'elementPropertyValue');
       chai.assert.equal((el as any).behaviorProperty, 'behaviorPropertyValue');
     });
+
+    test('throws when element names do not match', function() {
+      chai.assert.throws(() => {
+        @customElement('test-name-1')
+        class TestElement extends Polymer.Element {
+          static is = 'test-name-2';
+        }
+      });
+      chai.assert.isUndefined(customElements.get('test-name-1'));
+      chai.assert.isUndefined(customElements.get('test-name-2'));
+    });
   });
 
   suite('@property', function() {


### PR DESCRIPTION
An exception is now thrown if both the `tagname` parameter to `@customElement` is provided, and the static `is` class property is set (except in the case that the `is` property is not an own-property of the class). Previously the `is` property would always silently win over the `tagname` when both were set.

Fixes #41.