### PR TITLE
Typechecking improvements to the Polymer 2 TS decorators:

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,29 +147,13 @@ get fooBar() {
 }
 ```
 
-> ⚠️ **NOTE**: Since TypeScript 2.7, any use of `@computed` with >1 dependencies
-> will not compile unless the generic type parameter is specified explicitly
-> (either with the element class as shown below, or simply with `any`). See
-> [#48](https://github.com/Polymer/polymer-decorators/issues/48) for details.
-
-For optional additional type saftey, pass your custom element class as a
-generic parameter. This allows TypeScript to check that all of your
-dependencies are valid properties.
-
-```ts
-@computed<MyElement>('foo', 'bar')
-get fooBar() {
-  return this.foo + this.bar;
-}
-```
-
 To set the type of a computed property when the Metadata Reflection API is not
 available, apply an additional `@property` decorator. Note that the `@property`
 decorator should be applied first, but since decorators are executed bottom up,
 it should be written second:
 
 ```ts
-@computed<MyElement>('foo', 'bar')
+@computed('foo', 'bar')
 @property({type: String})
 get fooBar() {
 ```

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "polymer-decorators*.tgz"
   ],
   "dependencies": {
-    "polymer": "^2.4"
+    "Polymer/polymer": "^2.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,8 @@
     "test",
     "tests",
     "polymer-decorators*.tgz"
-  ]
+  ],
+  "dependencies": {
+    "polymer": "^2.4"
+  }
 }

--- a/mixins/declarative-event-listeners.d.ts
+++ b/mixins/declarative-event-listeners.d.ts
@@ -8,6 +8,9 @@
  *   mixins/declarative-event-listeners.html
  */
 
+/// <reference path="../../polymer/types/lib/utils/boot.d.ts" />
+/// <reference path="../../polymer/types/lib/utils/mixin.d.ts" />
+
 declare namespace Polymer {
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,6 +284,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bower": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "lib/decorators.js",
   "types": "lib/decorators.d.ts",
   "scripts": {
+    "postinstall": "bower install",
     "clean": "rimraf lib/ polymer-decorators.{js,d.ts} mixins/*.d.ts test/integration/{node_modules,bower_components,bower_cache}",
     "format": "find src test \\( -name node_modules -o -name bower_components -o -name bower_cache \\) -prune -o -name '*.ts' -print | xargs clang-format --style=file -i",
     "build": "npm run clean && tsc && rollup -c && node scripts/gen-global-typings.js && gen-typescript-declarations --outDir=.",
@@ -27,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.1.3",
+    "bower": "^1.8.2",
     "clang-format": "^1.0.55",
     "rimraf": "^2.6.2",
     "rollup": "^0.55.0",

--- a/polymer-decorators.d.ts
+++ b/polymer-decorators.d.ts
@@ -3,7 +3,6 @@
 
 declare namespace Polymer {
   namespace decorators {
-    /// <reference path="../bower_components/polymer/types/polymer-element.d.ts" />
     /**
      * @license
      * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.

--- a/polymer-decorators.d.ts
+++ b/polymer-decorators.d.ts
@@ -3,6 +3,7 @@
 
 declare namespace Polymer {
   namespace decorators {
+    /// <reference path="../bower_components/polymer/types/polymer-element.d.ts" />
     /**
      * @license
      * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
@@ -21,7 +22,7 @@ declare namespace Polymer {
         observers?: string[];
         _addDeclarativeEventListener?: (target: string | EventTarget, eventName: string, handler: (ev: Event) => void) => void;
     }
-    interface ElementPrototype {
+    interface ElementPrototype extends Polymer.Element {
         constructor: ElementConstructor;
     }
     /**
@@ -34,7 +35,7 @@ declare namespace Polymer {
      * or if both exist but have different values (except in the case that the `is`
      * property is not an own-property of the class), an exception is thrown.
      */
-    function customElement(tagname?: string): (class_: ElementConstructor) => void;
+    function customElement(tagname?: string): (class_: (new () => Polymer.Element) & ElementConstructor) => void;
     /**
      * Options for the @property decorator.
      * See https://www.polymer-project.org/2.0/docs/devguide/properties.
@@ -73,12 +74,14 @@ declare namespace Polymer {
      *
      * This function must be invoked to return a decorator.
      */
-    function computed<T = any>(...targets: (keyof T)[]): (proto: ElementPrototype, propName: string, descriptor: PropertyDescriptor) => void;
+    function computed<P extends string, El extends ElementPrototype & {
+        [K in P]: {} | null | undefined;
+    }>(firstTarget: P, ...moreTargets: P[]): (proto: El, propName: string, descriptor: PropertyDescriptor) => void;
     /**
      * A TypeScript property decorator factory that converts a class property into
      * a getter that executes a querySelector on the element's shadow root.
      *
-     * By annotating the property with the correct type, element's can have
+     * By annotating the property with the correct type, elements can have
      * type-checked access to internal elements.
      *
      * This function must be invoked to return a decorator.
@@ -88,13 +91,16 @@ declare namespace Polymer {
      * A TypeScript property decorator factory that converts a class property into
      * a getter that executes a querySelectorAll on the element's shadow root.
      *
-     * By annotating the property with the correct type, element's can have
+     * By annotating the property with the correct type, elements can have
      * type-checked access to internal elements. The type should be NodeList
      * with the correct type argument.
      *
      * This function must be invoked to return a decorator.
      */
     const queryAll: (selector: string) => (proto: ElementPrototype, propName: string) => void;
+    type HasEventListener<P extends string> = {
+        [K in P]: (e: Event) => void;
+    };
     /**
      * A TypeScript property decorator factory that causes the decorated method to
      * be called when a imperative event is fired on the targeted element. `target`
@@ -108,7 +114,7 @@ declare namespace Polymer {
      * @param eventName A string representing the event type to listen for
      * @param target A single element by id or EventTarget to target
      */
-    const listen: (eventName: string, target: string | EventTarget) => (proto: ElementPrototype, methodName: string) => void;
+    function listen(eventName: string, target: string | EventTarget): <P extends string, El extends ElementPrototype & HasEventListener<P>>(proto: El, methodName: P) => void;
     
   }
 }

--- a/polymer-decorators.js
+++ b/polymer-decorators.js
@@ -14,6 +14,7 @@ this.Polymer.decorators = (function (exports) {
  * Google as part of the polymer project is also subject to an additional IP
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
+/// <reference path="../bower_components/polymer/types/polymer-element.d.ts" />
 /**
  * A TypeScript class decorator factory that registers the class as a custom
  * element.
@@ -96,19 +97,20 @@ function observe(...targets) {
  *
  * This function must be invoked to return a decorator.
  */
-function computed(...targets) {
+function computed(firstTarget, ...moreTargets) {
     return (proto, propName, descriptor) => {
         const fnName = `__compute${propName}`;
         Object.defineProperty(proto, fnName, { value: descriptor.get });
         descriptor.get = undefined;
-        createProperty(proto, propName, { computed: `${fnName}(${targets.join(',')})` });
+        const targets = [firstTarget, ...moreTargets].join(',');
+        createProperty(proto, propName, { computed: `${fnName}(${targets})` });
     };
 }
 /**
  * A TypeScript property decorator factory that converts a class property into
  * a getter that executes a querySelector on the element's shadow root.
  *
- * By annotating the property with the correct type, element's can have
+ * By annotating the property with the correct type, elements can have
  * type-checked access to internal elements.
  *
  * This function must be invoked to return a decorator.
@@ -118,7 +120,7 @@ const query = _query((target, selector) => target.querySelector(selector));
  * A TypeScript property decorator factory that converts a class property into
  * a getter that executes a querySelectorAll on the element's shadow root.
  *
- * By annotating the property with the correct type, element's can have
+ * By annotating the property with the correct type, elements can have
  * type-checked access to internal elements. The type should be NodeList
  * with the correct type argument.
  *
@@ -155,16 +157,15 @@ function _query(queryFn) {
  * @param eventName A string representing the event type to listen for
  * @param target A single element by id or EventTarget to target
  */
-const listen = (eventName, target) => (proto, methodName) => {
-    if (!proto.constructor._addDeclarativeEventListener) {
-        throw new Error(`Cannot add listener for ${eventName} because ` +
-            `DeclarativeEventListeners mixin was not applied to element.`);
-    }
-    proto.constructor._addDeclarativeEventListener(target, eventName, 
-    // This cast to any is safe because proto[methodName] is, by
-    // definition, the method that we are currently decorating.
-    proto[methodName]);
-};
+function listen(eventName, target) {
+    return (proto, methodName) => {
+        if (!proto.constructor._addDeclarativeEventListener) {
+            throw new Error(`Cannot add listener for ${eventName} because ` +
+                `DeclarativeEventListeners mixin was not applied to element.`);
+        }
+        proto.constructor._addDeclarativeEventListener(target, eventName, proto[methodName]);
+    };
+}
 
 exports.customElement = customElement;
 exports.property = property;

--- a/polymer-decorators.js
+++ b/polymer-decorators.js
@@ -14,7 +14,6 @@ this.Polymer.decorators = (function (exports) {
  * Google as part of the polymer project is also subject to an additional IP
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
-/// <reference path="../bower_components/polymer/types/polymer-element.d.ts" />
 /**
  * A TypeScript class decorator factory that registers the class as a custom
  * element.

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,8 +9,6 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-/// <reference path="../polymer/types/polymer-element.d.ts" />
-
 export interface ElementConstructor extends Function {
   is?: string;
   properties?: {[prop: string]: PropertyOptions};
@@ -36,7 +34,7 @@ export interface ElementPrototype extends Polymer.Element {
  * property is not an own-property of the class), an exception is thrown.
  */
 export function customElement(tagname?: string) {
-  return (class_: {new(): Polymer.Element} & ElementConstructor) => {
+  return (class_: {new (): Polymer.Element}&ElementConstructor) => {
     if (tagname) {
       // Only check that tag names match when `is` is our own property. It might
       // be inherited from a superclass, in which case it's ok if they're
@@ -143,10 +141,9 @@ export function observe(...targets: string[]) {
  *
  * This function must be invoked to return a decorator.
  */
-export function computed<
-    P extends string,
-    El extends ElementPrototype & {[K in P]: {}|null|undefined}>(
-        firstTarget: P, ...moreTargets: P[]) {
+export function computed<P extends string, El extends ElementPrototype&
+                         {[K in P]: {} | null | undefined}>(
+    firstTarget: P, ...moreTargets: P[]) {
   return (proto: El,
           propName: string,
           descriptor: PropertyDescriptor): void => {
@@ -157,8 +154,7 @@ export function computed<
     descriptor.get = undefined;
 
     const targets = [firstTarget, ...moreTargets].join(',');
-    createProperty(
-        proto, propName, {computed: `${fnName}(${targets})`});
+    createProperty(proto, propName, {computed: `${fnName}(${targets})`});
   };
 }
 
@@ -208,7 +204,9 @@ function _query(
   };
 }
 
-export type HasEventListener<P extends string> = {[K in P]: (e: Event) => void};
+export type HasEventListener<P extends string> = {
+  [K in P]: (e: Event) => void
+};
 
 /**
  * A TypeScript property decorator factory that causes the decorated method to
@@ -224,16 +222,14 @@ export type HasEventListener<P extends string> = {[K in P]: (e: Event) => void};
  * @param target A single element by id or EventTarget to target
  */
 export function listen(eventName: string, target: string|EventTarget) {
-  return <P extends string, El extends ElementPrototype & HasEventListener<P>>(
-      proto: El, methodName: P) => {
+  return <P extends string, El extends ElementPrototype&HasEventListener<P>>(
+             proto: El, methodName: P) => {
     if (!proto.constructor._addDeclarativeEventListener) {
       throw new Error(
           `Cannot add listener for ${eventName} because ` +
           `DeclarativeEventListeners mixin was not applied to element.`);
     }
     proto.constructor._addDeclarativeEventListener(
-        target,
-        eventName,
-        (proto as HasEventListener<P>)[methodName]);
+        target, eventName, (proto as HasEventListener<P>)[methodName]);
   };
 }

--- a/test/integration/bower.json
+++ b/test/integration/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "polymer-decorators-integration-test",
   "dependencies": {
-    "polymer": "#d7ea2464cd7e798c1bc4ebf25e12d17c43a6f8b4",
+    "polymer": "^2.4",
     "webcomponentsjs": "^1.0.12",
     "polymer-decorators": "../../",
     "reflect-metadata": "rbuckton/reflect-metadata#^0.1.10"

--- a/test/integration/elements/declarative-listener-test-element.ts
+++ b/test/integration/elements/declarative-listener-test-element.ts
@@ -22,17 +22,17 @@ class DeclarativeListenerTestElement extends Polymer.DeclarativeEventListeners
   windowClickCounter: number = 0;
 
   @listen('element-event', 'tapRegion')
-  private elementEventHandler(e: Event) {
+  elementEventHandler(e: Event) {
     this.elementClickCounter++;
   }
 
   @listen('document-event', document)
-  private documentEventHandler(e: Event) {
+  documentEventHandler(e: Event) {
     this.documentClickCounter++;
   }
 
   @listen('window-event', window)
-  private windowEventHandler(e: Event) {
+  windowEventHandler(e: Event) {
     this.windowClickCounter++;
   }
 }

--- a/test/integration/elements/gesture-listener-test-element.ts
+++ b/test/integration/elements/gesture-listener-test-element.ts
@@ -25,22 +25,22 @@ class GestureListenerTestElement extends Polymer.DeclarativeEventListeners
   windowClickCounter: number = 0;
 
   @listen('tap', 'tapRegion')
-  private elementTapEventHandler(e: Event) {
+  elementTapEventHandler(e: Event) {
     this.elementClickCounter++;
   }
 
   @listen('tap', document)
-  private documentTapEventHandler(e: Event) {
+  documentTapEventHandler(e: Event) {
     this.documentClickCounter++;
   }
 
   @listen('tap', window)
-  private windowTapEventHandler(e: Event) {
+  windowTapEventHandler(e: Event) {
     this.windowClickCounter++;
   }
 
   @listen('element-event', 'tapRegion')
-  private elementEventHandler(e: Event) {
+  elementEventHandler(e: Event) {
     this.nonGestureElementClickCounter++;
   }
 }

--- a/test/integration/elements/test-element.ts
+++ b/test/integration/elements/test-element.ts
@@ -49,7 +49,7 @@ class TestElement extends Polymer.Element {
     return this.dependencyOne;
   }
 
-  @computed<TestElement>('dependencyOne', 'dependencyTwo')
+  @computed('dependencyOne', 'dependencyTwo')
   get computedTwo() {
     return this.dependencyOne + this.dependencyTwo;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "bower_components/polymer/types/polymer-element.d.ts"
   ]
 }


### PR DESCRIPTION
* Ensure that @customElement() is applied to a Polymer.Element constructor, and that
  all the other decorators are applied to a Polymer.Element prototype.

* Make @computed() typecheck properly without ever having to specify a type parameter.
  Also removed the possibility of invoking @computed() without arguments -- is that
  something that even makes sense? It causes issues with the new type signature.

* Make @listen() check that the function accepts an argument of type Event.

* Plus a couple of drive-by typo/lint fixes.