### PR TITLE
Add @ExportDecoratedItems where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+- Add @ExportDecoratedItems annotations to decorators, for use by tsickle.
 
 ## [2.0.1] - 2018-05-16
 - A warning is no longer emitted when a computed property does not have

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/decorators",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/polymer-decorators.d.ts
+++ b/polymer-decorators.d.ts
@@ -55,6 +55,8 @@ declare namespace Polymer {
      * property.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function property(options?: PropertyOptions): (proto: ElementPrototype, propName: string) => void;
     /**
@@ -62,6 +64,8 @@ declare namespace Polymer {
      * be called when a property changes.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function observe(...targets: string[]): (proto: ElementPrototype, propName: string) => void;
     /**
@@ -72,6 +76,8 @@ declare namespace Polymer {
      * The decorated getter should not have an associated setter.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function computed<P extends string, El extends ElementPrototype & {
         [K in P]: {} | null | undefined;
@@ -112,6 +118,8 @@ declare namespace Polymer {
      *
      * @param eventName A string representing the event type to listen for
      * @param target A single element by id or EventTarget to target
+     *
+     * @ExportDecoratedItems
      */
     function listen(eventName: string, target: string | EventTarget): <P extends string, El extends ElementPrototype & HasEventListener<P>>(proto: El, methodName: P) => void;
     

--- a/polymer-decorators.js
+++ b/polymer-decorators.js
@@ -71,6 +71,8 @@ this.Polymer.decorators = (function (exports) {
      * property.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function property(options) {
         return (proto, propName) => {
@@ -82,6 +84,8 @@ this.Polymer.decorators = (function (exports) {
      * be called when a property changes.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function observe(...targets) {
         return (proto, propName) => {
@@ -99,6 +103,8 @@ this.Polymer.decorators = (function (exports) {
      * The decorated getter should not have an associated setter.
      *
      * This function must be invoked to return a decorator.
+     *
+     * @ExportDecoratedItems
      */
     function computed(firstTarget, ...moreTargets) {
         return (proto, propName, descriptor) => {
@@ -159,6 +165,8 @@ this.Polymer.decorators = (function (exports) {
      *
      * @param eventName A string representing the event type to listen for
      * @param target A single element by id or EventTarget to target
+     *
+     * @ExportDecoratedItems
      */
     function listen(eventName, target) {
         return (proto, methodName) => {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -114,6 +114,8 @@ function createProperty(
  * property.
  *
  * This function must be invoked to return a decorator.
+ *
+ * @ExportDecoratedItems
  */
 export function property(options?: PropertyOptions) {
   return (proto: ElementPrototype, propName: string) => {
@@ -126,6 +128,8 @@ export function property(options?: PropertyOptions) {
  * be called when a property changes.
  *
  * This function must be invoked to return a decorator.
+ *
+ * @ExportDecoratedItems
  */
 export function observe(...targets: string[]) {
   return (proto: ElementPrototype, propName: string) => {
@@ -144,6 +148,8 @@ export function observe(...targets: string[]) {
  * The decorated getter should not have an associated setter.
  *
  * This function must be invoked to return a decorator.
+ *
+ * @ExportDecoratedItems
  */
 export function computed<P extends string, El extends ElementPrototype&
                          {[K in P]: {} | null | undefined}>(
@@ -224,6 +230,8 @@ export type HasEventListener<P extends string> = {
  *
  * @param eventName A string representing the event type to listen for
  * @param target A single element by id or EventTarget to target
+ *
+ * @ExportDecoratedItems
  */
 export function listen(eventName: string, target: string|EventTarget) {
   return <P extends string, El extends ElementPrototype&HasEventListener<P>>(


### PR DESCRIPTION
The @ExportDecoratedItems annotation is processed by tsickle, and results in @export annotations being emitted on all the elements the decorators are applied to. This prevents JsCompiler from renaming or deleting these symbols.

It prevents issues like:
* templates referencing a property that got renamed;
* computed properties not finding the property they depend upon because it got renamed;
* observers and listeners being dropped because nobody calls them.

It is not a full solution for template name safety, to do so one would have to generate externs from symbols referenced in the template, but it is the only solution to the second and third issue above.