### PR TITLE
HasEventListener should accept subtypes of Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 - Add `@ExportDecoratedItems` annotation to `@query` and `@queryAll` (used by
   tsickle).
+- The `@listen` decorator allows event handler functions that accept any
+  subtype of Event. So you can write an event listener that accepts e.g.
+  KeyboardEvent. Note that the relationship between the event name and
+  the event subtype is not checked.
 
 ## [3.0.0] - 2018-08-10
 - Updated for Polymer 3.0.

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -186,7 +186,7 @@ export function queryAll(selector: string) {
 }
 
 export type HasEventListener<P extends string> = {
-  [K in P]: (e: Event) => void
+  [K in P]: <E extends Event>(e: E) => void
 };
 
 /**


### PR DESCRIPTION
This is arguably less type safe, because we don't check that it's the right event type, but often it will be a CustomEvent that you can't easily type check at runtime.