### PR TITLE
fix(deps): fix error when installing Polymer bower dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "polymer-decorators*.tgz"
   ],
   "dependencies": {
-    "Polymer/polymer": "^2.4"
+    "polymer": "Polymer/polymer#^2.4"
   }
 }


### PR DESCRIPTION
Howdy 👋 ,

I'm unsure how or why or when, but recently something changed that prevents the v2.1.0 release of `polymer-decorators` from successfully being installed via Bower. As far as I can tell, the issue is that the `Polymer` dependency listed in this repo's `bower.json` is malformed, and Bower is now exploding on this instead of silently dropping it. This is the error that is produced now:

```
bower                                          ENOTFOUND Package Polymer/polymer=Polymer/polymer not found
```

In my testing, this PR seems to fix this issue.