### PR TITLE
Fix documentation - wrong order of properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ reference.
 @property({observer: MyElement.prototype.bazChanged, type: String})
 baz: string;
 
-private bazChanged(oldValue: string, newValue: string) {
+private bazChanged(newValue: string, oldValue: string) {
   console.log(`baz was: ${oldValue}, and is now: ${newValue}`);
 }
 ```


### PR DESCRIPTION
observer is using newValue as first parameter and oldValue as secondParameter
https://github.com/Polymer/polymer-decorators/blob/master/src/decorators.ts#L69